### PR TITLE
feat: Add support for gemini-2.5-flash-preview-05-20

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim):
 
 ### Google Gemini Models
 - Gemini 2.5 Pro `gemini-2.5-pro`
+- Gemini 2.5 Flash Preview 05-20 `gemini-2.5-flash-preview-05-20`
 - Gemini 2.5 Flash `gemini-2.5-flash`
 - Gemini 2.0 Flash `gemini-2.0-flash`
 - Gemini 2.0 Flash Thinking `gemini-2.0-flash-thinking-chat`

--- a/lua/llm-sidekick/models.lua
+++ b/lua/llm-sidekick/models.lua
@@ -212,13 +212,18 @@ return {
     max_tokens = 16384,
     temperature = 0.3,
   },
+  ["gemini-2.5-flash-preview-05-20"] = {
+    name = "gemini/gemini-2.5-flash-preview-05-20",
+    max_tokens = 65536,
+    temperature = 0.6,
+  },
   ["gemini-2.5-pro"] = {
     name = "gemini/gemini-2.5-pro-preview-05-06",
     max_tokens = 65536,
     temperature = 0.6,
   },
   ["gemini-2.5-flash"] = {
-    name = "gemini/gemini-2.5-flash-preview-04-17",
+    name = "gemini/gemini-2.5-flash-preview-05-20",
     max_tokens = 65536,
     temperature = 0.6,
   },


### PR DESCRIPTION
This commit introduces support for the new Google Gemini model `gemini-2.5-flash-preview-05-20`.

Changes include:
- Added `gemini-2.5-flash-preview-05-20` to `lua/llm-sidekick/models.lua`.
- Updated the `gemini-2.5-flash` model alias to default to `gemini/gemini-2.5-flash-preview-05-20`.
- Verified that no settings in `lua/llm-sidekick/settings.lua` were pointing to the older preview model.
- Updated `README.md` to list `gemini-2.5-flash-preview-05-20` as a supported model.