### PR TITLE
feat: Add support for CLAUDE.md memory files

### DIFF
--- a/lua/llm-sidekick/fs.lua
+++ b/lua/llm-sidekick/fs.lua
@@ -5,8 +5,139 @@ local M = {}
 ---@return string|nil content The file contents or nil if file cannot be opened
 function M.read_file(path)
   local ok, lines = pcall(vim.fn.readfile, path)
-  if not ok then return nil end
+  if not ok then
+    return nil
+  end
   return table.concat(lines, "\n")
+end
+
+local function expand_home(path)
+  if path:sub(1, 1) == "~" then
+    return vim.fn.expand("~") .. path:sub(2)
+  end
+  return path
+end
+
+local function normalize_path(path)
+  if path == nil or path == "" then return nil end
+  return vim.fn.fnamemodify(expand_home(path), ":p")
+end
+
+local function is_dir(path)
+  return vim.fn.isdirectory(path) == 1
+end
+
+local function get_parent_dir(path)
+  local parent = vim.fn.fnamemodify(path, ":h")
+  -- Handle root directory case or invalid paths
+  if parent == path or parent == "" or parent == nil then
+    return nil
+  end
+  return parent
+end
+
+---Find CLAUDE.md files based on different strategies.
+---@param opts table Options table:
+---  - search_strategy (string): "system_prompt" or "tool_operation"
+---  - cwd (string): Current working directory (for "system_prompt")
+---  - home_claude_file (string): Path to user's global Claude file (for "system_prompt")
+---  - start_dir (string): Directory to start search from (for "tool_operation")
+---  - stop_at_dir (string): Directory path to stop ascending
+---@return table A list of unique absolute paths to found CLAUDE.md files.
+function M.find_claude_md_files(opts)
+  local found_files = {}
+  local found_files_set = {}
+
+  local function add_file(path)
+    local abs_path = normalize_path(path)
+    if abs_path and not found_files_set[abs_path] then
+      table.insert(found_files, abs_path)
+      found_files_set[abs_path] = true
+    end
+  end
+
+  local stop_at = normalize_path(opts.stop_at_dir)
+  if not stop_at then
+    -- Default stop_at to user's home directory if not provided or invalid
+    stop_at = normalize_path("~")
+    if not stop_at then -- Fallback if home expansion somehow fails
+      return {} -- Cannot proceed without a valid stop_at
+    end
+  end
+
+  local function search_upwards(start_search_dir, stop_search_dir)
+    local search_results = {}
+    local current_dir = normalize_path(start_search_dir)
+
+    while current_dir do
+      if not is_dir(current_dir) then
+        current_dir = get_parent_dir(current_dir)
+        goto continue_while -- Skip if current_dir is not a directory (e.g. start_dir was a file)
+      end
+
+      local claude_file_path = current_dir .. "/CLAUDE.md"
+      -- Check if the file exists and is a file (not a directory)
+      if vim.fn.filereadable(claude_file_path) == 1 and vim.fn.isdirectory(claude_file_path) == 0 then
+        -- add_file handles normalization and uniqueness via found_files_set
+        -- We store it in search_results to maintain the specific order for this search pass
+        local abs_path = normalize_path(claude_file_path)
+        if abs_path and not found_files_set[abs_path] then
+            table.insert(search_results, abs_path)
+            -- Mark as globally found to respect uniqueness across different search passes
+            found_files_set[abs_path] = true
+        end
+      end
+
+      -- Stop if current_dir is the stop_search_dir
+      if current_dir == stop_search_dir then
+        break
+      end
+
+      local parent_dir = get_parent_dir(current_dir)
+      if not parent_dir or parent_dir == current_dir then -- Reached root or error
+        break
+      end
+      current_dir = parent_dir
+
+      ::continue_while::
+    end
+    return search_results
+  end
+
+  if opts.search_strategy == "system_prompt" then
+    if not opts.cwd or not opts.home_claude_file then
+      vim.notify("find_claude_md_files: 'cwd' and 'home_claude_file' are required for 'system_prompt' strategy", vim.log.levels.ERROR)
+      return {}
+    end
+
+    local upward_files = search_upwards(opts.cwd, stop_at)
+    -- Add files from deepest to shallowest
+    for i = 1, #upward_files do
+      table.insert(found_files, upward_files[i])
+    end
+
+    -- Add home_claude_file last, if it exists and is not already added
+    local home_claude_path = normalize_path(opts.home_claude_file)
+    if home_claude_path and vim.fn.filereadable(home_claude_path) == 1 and not found_files_set[home_claude_path] then
+      add_file(home_claude_path) -- add_file itself adds to found_files
+    end
+
+  elseif opts.search_strategy == "tool_operation" then
+    if not opts.start_dir then
+      vim.notify("find_claude_md_files: 'start_dir' is required for 'tool_operation' strategy", vim.log.levels.ERROR)
+      return {}
+    end
+    local upward_files = search_upwards(opts.start_dir, stop_at)
+    -- Add files from deepest to shallowest
+    for i = 1, #upward_files do
+      table.insert(found_files, upward_files[i])
+    end
+  else
+    vim.notify("find_claude_md_files: Invalid search_strategy: " .. tostring(opts.search_strategy), vim.log.levels.ERROR)
+    return {}
+  end
+
+  return found_files
 end
 
 return M

--- a/lua/llm-sidekick/prompts.lua
+++ b/lua/llm-sidekick/prompts.lua
@@ -1,13 +1,14 @@
+local fs = require("llm-sidekick.fs")
+
 --- Generates the system prompt for the LLM assistant
 --- @param opts table Configuration options for the system prompt
+--- @field buf number The buffer number where the prompt will be used
 --- @field os_name string? The operating system name (defaults to "macOS")
 --- @field shell string? The shell being used (defaults to "bash")
 --- @field cwd string The current working directory
 --- @field just_chatting boolean? Whether the assistant is in "just chatting" mode
 --- @field model string The model being used
 --- @return string The formatted system prompt
-local fs = require("llm-sidekick.fs")
-
 local function system_prompt(opts)
   local os_name = opts.os_name or "macOS"
   local shell = opts.shell or "bash"
@@ -15,66 +16,62 @@ local function system_prompt(opts)
   local just_chatting = opts.just_chatting
   local model = opts.model
 
-  -- Fetch and process CLAUDE.md files
-  local claude_content_parts = {}
-  local processed_claude_paths = {} -- To ensure content from a path is added only once
-  local home_dir = vim.fn.expand('~')
-  local claude_home_file_path = home_dir .. "/.claude/CLAUDE.md"
+  local project_instructions = {}
 
   if not just_chatting then -- Only load CLAUDE.md files if not in "just_chatting" mode
-    local claude_files = fs.find_claude_md_files({
-      search_strategy = "system_prompt",
-      cwd = cwd,
-      stop_at_dir = home_dir,
-      home_claude_file = claude_home_file_path
-    })
+    local claude_files = fs.find_claude_md_files({ buf = opts.buf, start_dir = cwd })
 
     for _, filepath in ipairs(claude_files) do
-      if not processed_claude_paths[filepath] then
-        local content = fs.read_file(filepath)
-        if content and content ~= "" then
-          table.insert(claude_content_parts, "--- CLAUDE.md content from " .. filepath .. " ---\n" .. content)
-          processed_claude_paths[filepath] = true
-        end
+      local content = fs.read_file(filepath)
+      if content and content ~= "" then
+        table.insert(project_instructions, "````" .. filepath .. "\n" .. content .. "\n````")
       end
     end
   end
-  local claude_content_str = table.concat(claude_content_parts, "\n\n")
+
+  if #project_instructions > 0 then
+    -- insert at the beginning of the file content
+    table.insert(project_instructions, 1,
+      "# Project-Specific Instructions\nFollow them to the best of your ability:")
+  end
+
+  local project_instructions_str = table.concat(project_instructions, "\n\n")
+
+  local str_replace_editor_tool_name = "str_replace_editor"
+  if model:find("claude-opus-4", 1, true) or model:find("claude-sonnet-4", 1, true) then
+    str_replace_editor_tool_name = "str_replace_based_edit_tool"
+  end
 
   -- Model-specific prompt additions
   local model_specific_additions = ""
   local tool_behavior_note = "\n" .. [[
-- Note on file operations: When using `str_replace_editor` or `str_replace_based_edit_tool` to view or edit files, any relevant `CLAUDE.md` files (from the file's directory or parent directories up to the project root, plus your global `~/.claude/CLAUDE.md`) will be automatically loaded. Their content will be provided to you separately from the actual file content to give you project-specific guidelines or context. This `CLAUDE.md` content is also part of this system prompt.]]
+- Note on file operations: When using `]] .. str_replace_editor_tool_name .. [[` to view or edit files, any relevant project instructions will be automatically loaded. Their content will be provided to you separately from the actual file content to give you project-specific guidelines or context. Follow these instructions carefully to align with the project's requirements and conventions.]]
 
-  if model and model:find("anthropic.claude-3-7-sonnet", 1, true) then
+  if model and model:find("claude-3-7-sonnet", 1, true) or model:find("claude-opus-4", 1, true) or
+      model:find("claude-sonnet-4", 1, true) then
     model_specific_additions = "\n" .. [[
-- Notes for using the `str_replace_editor` tool:
-* Prefer relative paths when working with files in the current working directory
-* Ensure each `old_str` is unique enough to match only the intended section.]] .. tool_behavior_note
+- Notes for using the `]] .. str_replace_editor_tool_name .. [[` tool:
+  * Prefer relative paths when working with files in the current working directory.
+  * Ensure each `old_str` is unique enough to match only the intended section.]] .. tool_behavior_note
   else
     model_specific_additions = "\n" .. [[
-- Notes for using the `str_replace_editor` tool:
-1. When using the `str_replace` command:
-   * The `old_str` parameter should match EXACTLY one or more consecutive lines from the original file. Be mindful of whitespaces!
-   * If the `old_str` parameter is not unique in the file, the replacement will not be performed. Make sure to include enough context in `old_str` to make it unique.
-   * The `new_str` parameter should contain the edited lines that should replace the `old_str`.
-2. Command usage patterns:
-   * To view a file: Use `command: "view"` with `path` to the file.
-   * To create a file: Use `command: "create"` with `path` and `file_text`
-   * To replace text: Use `command: "str_replace"` with `path`, `old_str`, and `new_str`
-3. Best practices:
-   * Always view a file before attempting to modify it
-   * When replacing text, include enough context in `old_str` to ensure uniqueness
-   * Prefer relative paths when working with files in the current working directory
-   * Use the `view` command with directories to explore the file structure]] .. tool_behavior_note
+- Notes for using the `]] .. str_replace_editor_tool_name .. [[` tool:
+  1. When using the `str_replace` command:
+     * The `old_str` parameter should match EXACTLY one or more consecutive lines from the original file. Be mindful of whitespaces!
+     * If the `old_str` parameter is not unique in the file, the replacement will not be performed. Make sure to include enough context in `old_str` to make it unique.
+     * The `new_str` parameter should contain the edited lines that should replace the `old_str`.
+  2. Command usage patterns:
+     * To view a file: Use `command: "view"` with `path` to the file.
+     * To create a file: Use `command: "create"` with `path` and `file_text`
+     * To replace text: Use `command: "str_replace"` with `path`, `old_str`, and `new_str`
+  3. Best practices:
+     * Always view a file before attempting to modify it
+     * When replacing text, include enough context in `old_str` to ensure uniqueness
+     * Prefer relative paths when working with files in the current working directory
+     * Use the `view` command with directories to explore the file structure]] .. tool_behavior_note
   end
 
-  local prompt = ""
-  if claude_content_str and claude_content_str ~= "" then
-    prompt = claude_content_str .. "\n\n"
-  end
-
-  prompt = prompt .. [[
+  local prompt = [[
 You are Zir, a highly skilled full-stack software engineer with extensive knowledge in many programming languages, frameworks, design patterns, and best practices, operating as an integrated development assistant within Neovim. You are working in a pair-programming session with a senior full-stack developer. You adapt to the developer's technical expertise level, but always maintain a professional engineering focus. Think of yourself as a proactive and insightful partner, not just a tool.
 
 Your primary purpose is to collaborate with the user on software development tasks. This means:
@@ -108,18 +105,21 @@ Your primary purpose is to collaborate with the user on software development tas
       (just_chatting and "" or [[
 
 - Structured Conclusions: As your collaborative partner, you will always conclude your responses thoughtfully. This means ending with either:
-  - Verification Questions: Ensure mutual understanding by asking targeted questions about the work completed
   - Important Considerations: Raise alerts about potential issues or critical factors that need attention
   - Next Steps: Offer constructive suggestions for improvements or future actions]]) ..
       [[
 
-# System Information
 
+# System Information
 Operating System: ]] .. os_name .. [[
 
 Default Shell: ]] .. shell .. [[
 
 Current Working Directory: ]] .. cwd .. "\n"
+
+  if project_instructions_str and project_instructions_str ~= "" then
+    prompt = prompt .. "\n" .. project_instructions_str .. "\n"
+  end
 
   return prompt
 end

--- a/lua/llm-sidekick/tools/file_operations/str_replace_based_edit_tool.lua
+++ b/lua/llm-sidekick/tools/file_operations/str_replace_based_edit_tool.lua
@@ -395,42 +395,32 @@ return {
         { success_message }
       )
 
-      -- Fetch and prepend CLAUDE.md content if any
-      local claude_md_contents = {}
-      local abs_path = vim.fn.fnamemodify(path, ":p")
-      local file_dir = vim.fn.fnamemodify(abs_path, ":h")
-      -- Use vim.fn.getcwd() as project_root as per plan
-      local project_root = vim.fn.getcwd()
+      local project_instructions = {}
+      local file_dir = vim.fn.fnamemodify(path, ":p:h")
 
       local claude_files = fs.find_claude_md_files({
-        search_strategy = "tool_operation",
+        buf = opts.buffer,
         start_dir = file_dir,
-        stop_at_dir = project_root,
+        stop_at_dir = vim.fn.getcwd(),
       })
 
-      local processed_claude_paths = {} -- Ensure uniqueness if fs layer didn't
       for _, claude_path in ipairs(claude_files) do
-        if not processed_claude_paths[claude_path] then
-          local content = fs.read_file(claude_path)
-          if content and content ~= "" then
-            table.insert(claude_md_contents, "-- CLAUDE.md content from " .. claude_path .. " --\n" .. content)
-            processed_claude_paths[claude_path] = true
-          end
+        local content = fs.read_file(claude_path)
+        if content and content ~= "" then
+          table.insert(project_instructions, "````" .. claude_path .. "\n" .. content .. "\n````")
         end
       end
 
-      local final_content_parts = {}
-      if #claude_md_contents > 0 then
-        table.insert(final_content_parts, "[START CLAUDE.MD CONTENT]")
-        table.insert(final_content_parts, table.concat(claude_md_contents, "\n\n---\n")) -- Separator for multiple CLAUDE files
-        table.insert(final_content_parts, "[END CLAUDE.MD CONTENT]\n")
+      if #project_instructions > 0 then
+        -- insert at the beginning of the file content
+        table.insert(project_instructions, 1,
+          "If the following project instructions are relevant, follow them to the best of your ability.")
       end
 
-      table.insert(final_content_parts, "[START FILE CONTENT: " .. path .. "]")
-      table.insert(final_content_parts, table.concat(content_lines, "\n"))
-      table.insert(final_content_parts, "[END FILE CONTENT: " .. path .. "]")
-
-      return table.concat(final_content_parts, "\n")
+      return {
+        project_instructions = table.concat(project_instructions, "\n\n"),
+        file_content = table.concat(content_lines, "\n")
+      }
     elseif tool_call.parameters.command == "str_replace" then
       local path = vim.trim(tool_call.parameters.path or "")
       local search = tool_call.parameters.old_str

--- a/lua/llm-sidekick/tools/file_operations/str_replace_based_edit_tool.lua
+++ b/lua/llm-sidekick/tools/file_operations/str_replace_based_edit_tool.lua
@@ -1,6 +1,7 @@
 local markdown = require("llm-sidekick.markdown")
 local chat = require("llm-sidekick.chat")
 local signs = require("llm-sidekick.signs")
+local fs = require("llm-sidekick.fs")
 
 local spec = {
   name = "str_replace_based_edit_tool",
@@ -394,7 +395,42 @@ return {
         { success_message }
       )
 
-      return table.concat(content_lines, "\n")
+      -- Fetch and prepend CLAUDE.md content if any
+      local claude_md_contents = {}
+      local abs_path = vim.fn.fnamemodify(path, ":p")
+      local file_dir = vim.fn.fnamemodify(abs_path, ":h")
+      -- Use vim.fn.getcwd() as project_root as per plan
+      local project_root = vim.fn.getcwd()
+
+      local claude_files = fs.find_claude_md_files({
+        search_strategy = "tool_operation",
+        start_dir = file_dir,
+        stop_at_dir = project_root,
+      })
+
+      local processed_claude_paths = {} -- Ensure uniqueness if fs layer didn't
+      for _, claude_path in ipairs(claude_files) do
+        if not processed_claude_paths[claude_path] then
+          local content = fs.read_file(claude_path)
+          if content and content ~= "" then
+            table.insert(claude_md_contents, "-- CLAUDE.md content from " .. claude_path .. " --\n" .. content)
+            processed_claude_paths[claude_path] = true
+          end
+        end
+      end
+
+      local final_content_parts = {}
+      if #claude_md_contents > 0 then
+        table.insert(final_content_parts, "[START CLAUDE.MD CONTENT]")
+        table.insert(final_content_parts, table.concat(claude_md_contents, "\n\n---\n")) -- Separator for multiple CLAUDE files
+        table.insert(final_content_parts, "[END CLAUDE.MD CONTENT]\n")
+      end
+
+      table.insert(final_content_parts, "[START FILE CONTENT: " .. path .. "]")
+      table.insert(final_content_parts, table.concat(content_lines, "\n"))
+      table.insert(final_content_parts, "[END FILE CONTENT: " .. path .. "]")
+
+      return table.concat(final_content_parts, "\n")
     elseif tool_call.parameters.command == "str_replace" then
       local path = vim.trim(tool_call.parameters.path or "")
       local search = tool_call.parameters.old_str

--- a/lua/llm-sidekick/tools/file_operations/str_replace_editor.lua
+++ b/lua/llm-sidekick/tools/file_operations/str_replace_editor.lua
@@ -354,7 +354,33 @@ return {
           { success_message }
         )
 
-        return table.concat(entries, "\n")
+        local project_instructions = {}
+        local file_dir = vim.fn.fnamemodify(path, ":p:h")
+
+        local claude_files = fs.find_claude_md_files({
+          buf = opts.buffer,
+          start_dir = file_dir,
+          stop_at_dir = vim.fn.getcwd(),
+        })
+
+        for _, claude_path in ipairs(claude_files) do
+          local content = fs.read_file(claude_path)
+          if content and content ~= "" then
+            table.insert(project_instructions, "````" .. claude_path .. "\n" .. content .. "\n````")
+          end
+        end
+
+        if #project_instructions > 0 then
+          table.insert(project_instructions, 1,
+            "If the following project instructions are relevant, follow them to the best of your ability.")
+
+          return {
+            project_instructions = table.concat(project_instructions, "\n\n"),
+            directories = table.concat(entries, "\n")
+          }
+        else
+          return table.concat(entries, "\n")
+        end
       end
 
       -- Handle file viewing
@@ -420,15 +446,16 @@ return {
       end
 
       if #project_instructions > 0 then
-        -- insert at the beginning of the file content
         table.insert(project_instructions, 1,
           "If the following project instructions are relevant, follow them to the best of your ability.")
-      end
 
-      return {
-        project_instructions = table.concat(project_instructions, "\n\n"),
-        file_content = table.concat(content_lines, "\n")
-      }
+        return {
+          project_instructions = table.concat(project_instructions, "\n\n"),
+          file_content = table.concat(content_lines, "\n")
+        }
+      else
+        return table.concat(content_lines, "\n")
+      end
     elseif tool_call.parameters.command == "str_replace" then
       local path = vim.trim(tool_call.parameters.path or "")
       local search = tool_call.parameters.old_str

--- a/plugin/llm-sidekick.lua
+++ b/plugin/llm-sidekick.lua
@@ -247,6 +247,12 @@ local ask_command = function()
       prompt_settings.temperature = model_settings.temperature
     end
 
+    local buf = vim.api.nvim_create_buf(true, true)
+    vim.bo[buf].buftype = "nofile"
+    vim.b[buf].is_llm_sidekick_chat = true
+    vim.g.llm_sidekick_last_chat_buffer = buf
+    vim.api.nvim_set_option_value("filetype", "markdown", { buf = buf })
+
     local prompt = ""
     if is_llm_sidekick_chat_file(0) and not vim.b.is_llm_sidekick_chat then
       prompt = table.concat(vim.api.nvim_buf_get_lines(0, 0, -1, false), "\n")
@@ -256,6 +262,7 @@ local ask_command = function()
       end
 
       local system_prompt = prompts.system_prompt({
+        buf = buf,
         os_name = utils.get_os_name(),
         shell = vim.o.shell or "bash",
         cwd = vim.fn.getcwd(),
@@ -302,12 +309,6 @@ The following additional instructions are provided by the user, and should be fo
       prompt = prompt .. "SYSTEM: " .. system_prompt
       prompt = prompt .. "\nUSER: "
     end
-
-    local buf = vim.api.nvim_create_buf(true, true)
-    vim.bo[buf].buftype = "nofile"
-    vim.b[buf].is_llm_sidekick_chat = true
-    vim.g.llm_sidekick_last_chat_buffer = buf
-    vim.api.nvim_set_option_value("filetype", "markdown", { buf = buf })
 
     local lines = vim.split(prompt, "[\r]?\n")
     vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)


### PR DESCRIPTION
This change introduces support for CLAUDE.md files, allowing you to provide project-specific and global instructions to me, similar to Claude Code's memory feature.

Key changes:

- **New FS Function:** I added `find_claude_md_files` to `lua/llm-sidekick/fs.lua`. This function searches for `CLAUDE.md` files based on different strategies:
    - For system prompts: I search from the current working directory up to the home directory, and also check `~/.claude/CLAUDE.md`.
    - For tool operations: I search from the target file's directory up to the project root.

- **System Prompt Integration:**
    - `lua/llm-sidekick/prompts.lua` now uses `find_claude_md_files` to locate relevant `CLAUDE.md` files.
    - The content of these files is prepended to the system prompt, providing context to me.
    - The system prompt now also informs me that file operation tools will provide `CLAUDE.md` content separately.

- **Tool Enhancement:**
    - `str_replace_editor.lua` and `str_replace_based_edit_tool.lua` (specifically their `view` command) now use `find_claude_md_files` to find `CLAUDE.md` files relevant to the file being viewed.
    - The content of these `CLAUDE.md` files is returned to me alongside the target file's content, but clearly demarcated using `[START CLAUDE.MD CONTENT]` and `[END CLAUDE.MD CONTENT]` markers. This gives me contextual information when viewing or preparing to edit files.

This feature enhances my ability to understand and adhere to project standards and your preferences by making relevant contextual information available automatically.